### PR TITLE
Updates RabbitMQSimpleConnectionFactory and adds connection names.

### DIFF
--- a/RabbitMQHosting/RabbitMQSimpleHosting.csproj
+++ b/RabbitMQHosting/RabbitMQSimpleHosting.csproj
@@ -2,14 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.3</Version>
+    <Version>2.0.0</Version>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
-    <PackageReference Include="RabbitMQSimpleConnectionFactory" Version="1.0.9" />
-    <PackageReference Include="RabbitMQSimpleConsumer" Version="1.1.0" />
+    <PackageReference Include="RabbitMQSimpleConnectionFactory" Version="2.1.0" />
+    <PackageReference Include="RabbitMQSimpleConsumer" Version="2.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
O que:
- Atualiza a dependência RabbitMQSimpleConnection factory.
- Atualiza o método MessagingJob.Start para criar um ChannelFactory e passar para a classe QueueManager ao invés de um ConnectionSetting.
- Atualiza o método MessagingJob.Start para especificar os nomes de cada conexão criada com o RabbitMQ.

Por que:
- Correções importantes foram feitas na RabbitMQSimpleConnectionFactory v2.1.0.
- Para permitir que seja criada uma conexão com o RabbitMQ para cada processor.
- Para possibilitar a identificação de uma ou mais conexões no RabbitMQ.